### PR TITLE
Adds handling for resolvers returning an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,10 @@ fmt.Printf("Random Number: %v\n", generator.Generate())
 * Must bind against an Interface or Pointer type
 * Resolvers must be a function
 * Resolver must return a type that either implements or is assignable to the
-  bound type
+  bound type as the first return parameter
 * Resolver may have arguments, but they must be of type Interface, Pointer, or
-  Slice so the container can attemp to resolve them.
+  Slice so the container can attemp to resolve them
+* If a Resolver returns an error, it must be the second return parameter
 
 ## Requirements To Resolve
 * Provide an Interface or Pointer bound type to resolve

--- a/container.go
+++ b/container.go
@@ -111,6 +111,13 @@ func resolveAllInstanceInternal(bindingType reflect.Type, container *Container) 
 			}()
 
 			values := resolverValue.Call(args)
+
+			if len(values) >= 2 && values[1].CanInterface() {
+				if err, ok := values[1].Interface().(error); ok {
+					return nil, fmt.Errorf("failed to resolve for interface (%v), resolver returned error: %w", bindingType.Name(), err)
+				}
+			}
+
 			container.resolverToConcrete[resolverValue] = values[0].Interface()
 		}
 

--- a/container_test.go
+++ b/container_test.go
@@ -1,6 +1,7 @@
 package container_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/gobros/container"
@@ -120,6 +121,23 @@ func TestNothingBoundResolveAll(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, 0, Str1InstanceNumber)
 	assert.Equal(t, 0, Str2InstanceNumber)
+
+	cleanup()
+}
+
+func TestResolverError(t *testing.T) {
+	// Given
+	setup()
+	container.Bind[PrimaryIDGiver](func() (*TestStruct1, error) {
+		return nil, errors.New("resolver did a bad!")
+	})
+
+	// When
+	val, err := container.Resolve[PrimaryIDGiver]()
+
+	// Then
+	assert.Error(t, err)
+	assert.Nil(t, val)
 
 	cleanup()
 }


### PR DESCRIPTION
Also adds documentation on how to return an error. It must be the second parameter returned from a resolver to processed.