### PR TITLE
No longer errors on nothing found for resolver slice arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ fmt.Printf("Random Number: %v\n", generator.Generate())
 * Resolver may have arguments, but they must be of type Interface, Pointer, or
   Slice so the container can attemp to resolve them
 * If a Resolver returns an error, it must be the second return parameter
+* If a resolver has any argument of type slice, it will receive an empty slice
+  if nothing is currently bound. The resolver is expected to handle empty slices.
 
 ## Requirements To Resolve
 * Provide an Interface or Pointer bound type to resolve

--- a/container.go
+++ b/container.go
@@ -138,7 +138,9 @@ func resolveArguments(container *Container, resolverValue reflect.Value, binding
 			sliceType := argType.Elem()
 			arg, err := resolveAllInstanceInternal(sliceType, container)
 			if err != nil {
-				return nil, fmt.Errorf("resolver dependency error, failed to resolve dependency (%v) for interface (%v): %w", argType, bindingType.Name(), err)
+				// It's better to return an empty slice to let the resolver handle the empty slice than error
+				emptySlice := reflect.MakeSlice(reflect.SliceOf(sliceType), 0, 0)
+				arg = emptySlice.Interface()
 			}
 			argVal := reflect.ValueOf(arg)
 			args[i] = argVal

--- a/container_test.go
+++ b/container_test.go
@@ -411,8 +411,9 @@ func TestResolverWithArgsMissingDependencies(t *testing.T) {
 	val, err := container.Resolve[IDAggregator]()
 
 	// Then
-	assert.Nil(t, val)
-	assert.Error(t, err)
+	assert.NoError(t, err)
+	assert.NotNil(t, val)
+	assert.Empty(t, val.GivePrimaryIDs())
 
 	cleanup()
 }

--- a/must_test.go
+++ b/must_test.go
@@ -329,7 +329,9 @@ func TestMustResolverWithArgsMissingDependencies(t *testing.T) {
 	container.MustBind[IDAggregator](NewTestIDAggregatorStruct)
 
 	// When & Then
-	assert.Panics(t, func() { container.MustResolve[IDAggregator]() })
+	val := container.MustResolve[IDAggregator]()
+	assert.NotNil(t, val)
+	assert.Empty(t, val.GivePrimaryIDs())
 
 	cleanup()
 }


### PR DESCRIPTION
If a resolver has an argument of type slice, we don't want to error if nothing is found. Instead, it's better to return an empty list and let the resolver handle the list.