### PR TITLE
Fixes error reporting when a nested dependency is missing

### DIFF
--- a/container.go
+++ b/container.go
@@ -153,7 +153,7 @@ func resolveArguments(container *Container, resolverValue reflect.Value, binding
 			argVal := reflect.ValueOf(arg)
 
 			if argVal.Len() == 0 {
-				return nil, fmt.Errorf("failed to resolve for interface (%v), nothing bound", bindingType.Name())
+				return nil, fmt.Errorf("resolver dependency error, failed to resolve dependency (%v) for interface (%v)", argType, bindingType.Name())
 			}
 
 			args[i] = argVal.Index(argVal.Len() - 1)

--- a/container_test.go
+++ b/container_test.go
@@ -423,6 +423,28 @@ func TestResolverWithArgsMissingSliceDependency(t *testing.T) {
 	cleanup()
 }
 
+func TestResolverWithMissingChainDependency(t *testing.T) {
+	// Given
+	setup()
+
+	// Depends on SecondaryIDGiver, which is not bound
+	container.Bind[SecondaryIDGiver](func(agg IDAggregator) *TestStruct2 {
+		return &TestStruct2{}
+	})
+	// Depends on SecondaryIDGiver, which is bound, but is also missing a dependency itself
+	container.Bind[PrimaryIDGiver](func(ids []SecondaryIDGiver) *TestStruct1 {
+		return &TestStruct1{}
+	})
+
+	// When
+	val, err := container.Resolve[PrimaryIDGiver]()
+
+	// Then
+	assert.Nil(t, val)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "IDAggregator")
+}
+
 func TestResolverWithArgsDependencyError(t *testing.T) {
 	// Given
 	setup()


### PR DESCRIPTION
A very unhelpful error message was returned that didn't specify what dependency was missing. Corrected error message to be more verbose to assist with debugging.