### PR TITLE
Fixes bug preventing error message from resolver being displayed

### DIFF
--- a/container.go
+++ b/container.go
@@ -132,7 +132,7 @@ func resolveAllInstanceInternal(bindingType reflect.Type, container *Container) 
 
 		// If we have 2 or more returns, the second return may be in an error state
 		if len(values) >= 2 && values[1].Interface() != nil {
-			return nil, fmt.Errorf("failed to resolve for interface (%v), resolver returned error: %w", bindingType.Name(), err)
+			return nil, fmt.Errorf("failed to resolve for interface (%v), resolver returned error: %w", bindingType.Name(), values[1].Interface().(error))
 		}
 
 		container.resolverToConcreteInstance[resolver] = values[0].Interface()

--- a/container_test.go
+++ b/container_test.go
@@ -142,6 +142,7 @@ func TestResolverError(t *testing.T) {
 
 	// Then
 	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "resolver did a bad!")
 	assert.Nil(t, val)
 
 	cleanup()
@@ -160,6 +161,7 @@ func TestResolverErrorPanic(t *testing.T) {
 
 	// Then
 	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "resolver did a bad!")
 	assert.Nil(t, val)
 
 	cleanup()


### PR DESCRIPTION
If a resolver encountered an error, we weren't correctly including that error in our composed resolution error. Updated tests to catch this and then fixed the issue. Also updated resolver panic test to watch for this case.

This cast is safe because I've already ensured any resolver with 2 or more params has an error as the second: https://github.com/gobros/container/blob/fix-resolver-error/container.go#L209-L212